### PR TITLE
Fix findTaxByRate: filter active rates and prefer the standard VAT code

### DIFF
--- a/splash/src/Services/TaxManager.php
+++ b/splash/src/Services/TaxManager.php
@@ -40,7 +40,15 @@ class TaxManager
         $sql .= " t.localtax1_type, t.localtax2 as localtax2_tx, t.localtax2_type,";
         $sql .= " t.recuperableonly as npr";
         $sql .= " FROM ".MAIN_DB_PREFIX."c_tva as t";
-        $sql .= " WHERE t.fk_pays = ".$countryId." AND t.taux = ".$vatRate;
+        $sql .= " WHERE t.fk_pays = ".$countryId." AND t.taux = ".$vatRate." AND t.active = 1";
+        //====================================================================//
+        // Order results so we always pick the standard sale VAT code first:
+        // a code like TVAFR20 before IMMO/CEE variants, any code before the
+        // code-less row, the recoverable rate before NPR ones, rowid to be stable.
+        $sql .= " ORDER BY (t.code LIKE 'TVA%') DESC,";
+        $sql .= " (t.code IS NOT NULL AND t.code <> '') DESC,";
+        $sql .= " t.recuperableonly ASC, t.rowid ASC";
+        $sql .= " LIMIT 1";
         $results = $db->query($sql);
         if ($results) {
             return  $db->fetch_object($results);


### PR DESCRIPTION
## Problem

`TaxManager::findTaxByRate()` builds:

```sql
SELECT ... FROM llx_c_tva t WHERE t.fk_pays = X AND t.taux = Y
```

with **no `active` filter and no `ORDER BY`**, then returns `fetch_object()` (the first row).

When a country has several rows for the same rate — typical FR 20%: a code-less row + `TVAFR20` + `IMMO` + intra-community `CEE*` — the row returned is non-deterministic and, in practice, often the **code-less** one. Splash then writes an **empty `default_vat_code`** on synced products.

Downstream, Dolibarr's line VAT auto-fill (`load_tva()` in mode > 0) offers options like `20 (TVAFR20)`; a product with an empty code matches none of them, so **the VAT is not auto-selected** on proposal / order / invoice lines. It also matters for Factur-X, where a VAT category code is expected.

## Fix

- Filter on `t.active = 1` (consistent with `findTaxByCode()` right below).
- Add a deterministic `ORDER BY` that prefers the standard sale code:
  1. `t.code LIKE 'TVA%'` — the standard code (`TVAFR20`) before `IMMO` / `CEE*` variants;
  2. a non-empty code before the code-less row;
  3. `recuperableonly ASC` — the normal (recoverable) rate before NPR ones;
  4. `t.rowid ASC` — stable tie-break.
- `LIMIT 1`.

For a rate that only exists code-less in the dictionary, the query still returns the code-less row — consistent with the line select, which has no code there either.

## Compatibility

`$countryId` / `$vatRate` are typed `int` / `float`, so the concatenation stays injection-safe (unchanged from before). The existing `L02TaxesByCodesTest` (sets up `TVAFR05/10/20` and asserts `vat_src_code`) keeps passing — the new ordering deterministically selects those standard codes.

Opened as a draft for review.
