### PR TITLE
Run Dolibarr product hooks through the webservice (init hook context)

### DIFF
--- a/splash/src/Local.php
+++ b/splash/src/Local.php
@@ -190,6 +190,21 @@ class Local implements LocalClassInterface
             MultiCompany::setup();
         }
 
+        //====================================================================//
+        // Ensure Dolibarr hooks fired inside core computations also run here:
+        // the webservice never calls initHooks(), so the global HookManager
+        // carries no context and modules hooking the product (e.g. virtual
+        // stock adjusters via the 'loadvirtualstock' hook) stay silent --
+        // the synced stock then differs from what Dolibarr itself displays.
+        global $db, $hookmanager;
+        if (!is_object($hookmanager) && is_object($db)) {
+            require_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
+            $hookmanager = new \HookManager($db);
+        }
+        if (is_object($hookmanager)) {
+            $hookmanager->initHooks(array('productdao'));
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Problem

Dolibarr modules can adjust the **virtual stock** through the `loadvirtualstock` hook, fired inside `Product::load_virtual_stock()`. But hooks only execute for classes registered with `initHooks()` — which every Dolibarr page calls, and the Splash webservice never does. The global HookManager carries no context on that path, so any module hooking the product stays silent during a sync.

Observed in production (Dolibarr 24.0, module 2.0.10): a module restricts the virtual stock to sellable warehouses; the product card shows the right value, but Splash reads and pushes the **total stock of all warehouses** to WooCommerce — e.g. 1869 synced where Dolibarr displays 375, or 816 synced for a product whose sellable stock is 0. Any installation using a virtual-stock module (quarantine, assembly warehouses, repairs…) silently oversells.

## Fix

At the end of `Local::includes()`, create the global HookManager if absent and `initHooks(array('productdao'))`, so core product computations behave the same through the webservice as they do in the back office. No behaviour change for installations without product hooks.

Verified end-to-end on the production installation above: after the change, the webservice path returns exactly the values shown on the product cards.
