### PR TITLE
Resolve line VAT code from the rate when the source sends no tax name

### DIFF
--- a/splash/src/Core/BaseItemsTrait.php
+++ b/splash/src/Core/BaseItemsTrait.php
@@ -641,6 +641,20 @@ trait BaseItemsTrait
                 $vatRateOrId = $identifiedVat->rowid;
                 $useId = true;
             }
+            //====================================================================//
+            // No Vat Src Code received => Resolve it from the Vat Rate
+            //
+            // Sources that carry no tax name (e.g. a 0% line on an export
+            // order) would leave vat_src_code empty on the line, even when the
+            // rate identifies a dictionary entry. Resolve by rate and store
+            // the code so accounting exports get a fully qualified tax.
+            if (!$useId && ($identifiedVat = TaxManager::findTaxByRate((float) $this->currentItem->tva_tx))) {
+                if (!empty($identifiedVat->code)) {
+                    $this->currentItem->vat_src_code = $identifiedVat->code;
+                }
+                $vatRateOrId = $identifiedVat->id;
+                $useId = true;
+            }
         }
 
         //====================================================================//


### PR DESCRIPTION
## Problem

When the remote source sends order/invoice lines **without a tax name** — the typical case being a 0% line on an export order pushed from WooCommerce, where no tax rate matches so no name exists — the connector stores the line with an **empty `vat_src_code`**, even when the rate alone identifies a VAT dictionary entry (e.g. rate `0` → `TVA0` on a French setup).

Accounting transfers and e-invoicing (Factur-X) then receive a rate without its qualifying code.

## Fix

In `updateItemTotals()`, when `SPLASH_DETECT_TAX_NAME` is enabled and `findTaxByCode()` matched nothing, resolve the dictionary entry **from the line rate** via `findTaxByRate()` — which since #17 prefers the standard active sale code — and store the resolved code on the line before totals are computed.

Lines that do carry a resolvable name are untouched; the fallback only fills the gap.

## Notes

- Builds on #17 (ordering of `findTaxByRate`), works without it too.
- Verified on a live Dolibarr 24.0 + WooCommerce pair: 0% export lines now land with `vat_src_code = TVA0` instead of empty.
