### PR TITLE
Keep the current ThirdParty when the source sends an unresolvable customer link

### DIFF
--- a/splash/src/Core/CustomerTrait.php
+++ b/splash/src/Core/CustomerTrait.php
@@ -167,7 +167,25 @@ trait CustomerTrait
                 //====================================================================//
                 // Standard Mode => A SocId is Required
                 if (!$this->isAllowedGuest()) {
-                    $this->setSimple($fieldName, self::objects()->id((string) $fieldData));
+                    //====================================================================//
+                    // An unresolved customer link must never overwrite the ThirdParty
+                    //
+                    // When the source cannot resolve the customer (ThirdParty not
+                    // linked on its side), writing the raw value sets socid to null
+                    // and the update fails on "Column 'fk_soc' cannot be null".
+                    // Keep the current ThirdParty and warn; error only when the
+                    // object has none.
+                    $newSocId = self::objects()->id((string) $fieldData);
+                    if (!empty($newSocId)) {
+                        $this->setSimple($fieldName, $newSocId);
+                    } elseif (empty($this->object->socid)) {
+                        Splash::log()->err("ErrLocalFieldMissing", __CLASS__, __FUNCTION__, "socid");
+                    } else {
+                        Splash::log()->war(sprintf(
+                            "Customer link not resolved by the source, keeping current ThirdParty (%s).",
+                            (string) $this->object->socid
+                        ));
+                    }
 
                     break;
                 }


### PR DESCRIPTION
## Problem

When the remote source cannot resolve an order/invoice **customer** — its ThirdParty object is not linked/synced on the source side — the connector writes the unresolved value anyway: `setCustomerFields('socid')` stores `objects()->id($fieldData)` even when that resolves to nothing, so `socid` becomes **null** and the update then dies with:

```
Order::update() => Error : Column 'fk_soc' cannot be null
Unable to Update Customer Order (…)
```

The whole object sync is blocked, even though the local order already has a perfectly valid customer that nobody asked to change.

## Fix

Only overwrite `socid` when the incoming link actually resolves to a local ThirdParty:

- resolved → written, as before;
- unresolved on an object that **has** a customer → keep the current ThirdParty, log a warning;
- unresolved on an object with **no** customer (creation case) → same `ErrLocalFieldMissing` error as `doCustomerDetection()`.

Same protection philosophy as #25: what the source cannot express must not destroy local data.

Reproduced and verified on a live Dolibarr 24.0 + WooCommerce pair: a full-field push with an unlinked customer now completes with a warning and the order keeps its ThirdParty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
