### PR TITLE
Let a credit note say which invoice it corrects (fk_facture_source)

### DIFF
--- a/splash/src/Objects/Invoice/CoreTrait.php
+++ b/splash/src/Objects/Invoice/CoreTrait.php
@@ -16,7 +16,10 @@
 namespace Splash\Local\Objects\Invoice;
 
 use DateTime;
+use Facture;
+use Splash\Core\SplashCore as Splash;
 use Splash\Local\Local;
+use Splash\Local\Objects\CreditNote;
 
 /**
  * Dolibarr Customer Invoice Fields (Required)
@@ -70,6 +73,22 @@ trait CoreTrait
             ->isIndexed()
             ->isListed()
         ;
+        //====================================================================//
+        // Source Invoice — credit notes only
+        //
+        // A credit note that does not say which invoice it corrects is an
+        // orphan: the source invoice stays settled at its full amount, and
+        // Dolibarr's own screens cannot offer to convert the credit note into
+        // a discount, because that conversion needs the link.
+        if ($this instanceof CreditNote) {
+            $this->fieldsFactory()->create((string) self::objects()->encode("Invoice", SPL_T_ID))
+                ->identifier("fk_facture_source")
+                ->name($langs->trans("CorrectInvoice"))
+                ->description($langs->trans("InvoiceReplacement"))
+                ->microData("http://schema.org/Invoice", "referencesOrder")
+                ->isIndexed()
+            ;
+        }
     }
 
     /**
@@ -99,6 +118,19 @@ trait CoreTrait
             case 'date':
                 $date = $this->object->date;
                 $this->out[$fieldName] = !empty($date)?dol_print_date($date, '%Y-%m-%d'):null;
+
+                break;
+                //====================================================================//
+                // Source Invoice — credit notes only
+            case 'fk_facture_source':
+                if (!$this instanceof CreditNote) {
+                    return;
+                }
+                $sourceId = (int) ($this->object->fk_facture_source ?? 0);
+                $this->out[$fieldName] = $sourceId
+                    ? self::objects()->encode("Invoice", (string) $sourceId)
+                    : null
+                ;
 
                 break;
             default:
@@ -150,9 +182,60 @@ trait CoreTrait
                 $this->setSimple('date_commande', $dateTime->getTimestamp());
 
                 break;
+                //====================================================================//
+                // Source Invoice — credit notes only
+            case 'fk_facture_source':
+                if (!$this instanceof CreditNote) {
+                    return;
+                }
+                $sourceId = $fieldData ? (int) self::objects()->id((string) $fieldData) : 0;
+                //====================================================================//
+                // Refuse a source that is not a real invoice of this entity, and
+                // refuse a credit note pointing at itself.
+                if ($sourceId && !$this->isValidSourceInvoice($sourceId)) {
+                    Splash::log()->errTrace("Invoice ".$sourceId." cannot be used as credit note source.");
+
+                    break;
+                }
+                if ((int) ($this->object->fk_facture_source ?? 0) !== $sourceId) {
+                    $this->setSimple('fk_facture_source', $sourceId ?: null);
+                }
+
+                break;
             default:
                 return;
         }
         unset($this->in[$fieldName]);
+    }
+
+    /**
+     * Check an Invoice may be used as the source of this Credit Note
+     *
+     * Dolibarr stores the link as a bare id, with no foreign key: an invalid
+     * value would be accepted silently and only surface much later, when the
+     * source invoice fails to load. It is cheaper to refuse it here.
+     *
+     * @param int $sourceId Candidate source invoice id
+     *
+     * @return bool
+     */
+    private function isValidSourceInvoice(int $sourceId): bool
+    {
+        global $db;
+
+        //====================================================================//
+        // A credit note cannot correct itself
+        if (!empty($this->object->id) && $sourceId === (int) $this->object->id) {
+            return false;
+        }
+        //====================================================================//
+        // The source must be an existing standard invoice of the same entity
+        $sql = "SELECT f.rowid FROM ".MAIN_DB_PREFIX."facture f";
+        $sql .= " WHERE f.rowid = ".$sourceId;
+        $sql .= " AND f.type != ".Facture::TYPE_CREDIT_NOTE;
+        $sql .= " AND f.entity IN (".getEntity('invoice').")";
+        $result = $db->query($sql);
+
+        return (bool) ($result && $db->num_rows($result));
     }
 }


### PR DESCRIPTION
Closes #28.

## The gap

The module already builds credit notes. `src/Objects/CreditNote.php` reuses the invoice traits, and
`Invoice/CRUDTrait` sets `type = Facture::TYPE_CREDIT_NOTE` on create. What it cannot express is
**which invoice the credit note corrects**: `fk_facture_source` appears nowhere in `src/`.

So every credit note that reaches Dolibarr through Splash arrives an orphan.

That link is not decoration:

- the source invoice stays settled at its full amount, so the customer ledger never nets out;
- Dolibarr's own screen cannot offer **convert into a discount** — `compta/facture/card.php` reaches
  `confirm_converttoreduc` through the source invoice, and that is the correct treatment when the
  money never actually moved (a waived fee, a goodwill gesture, a 100 % discount);
- reporting cannot pair a credit note with what it corrects.

## The change

`fk_facture_source` is exposed as an **Invoice object id**, declared only when the object is a
`CreditNote`, so standard invoices are untouched:

```php
if ($this instanceof CreditNote) {
    $this->fieldsFactory()->create((string) self::objects()->encode("Invoice", SPL_T_ID))
        ->identifier("fk_facture_source")
        ->name($langs->trans("CorrectInvoice"))
        ->microData("http://schema.org/Invoice", "referencesOrder")
        ->isIndexed()
    ;
}
```

Reads encode the stored id back into an `Invoice` object id, or `null` when unset.

## Writes are checked before they land

Dolibarr stores this link as a bare integer with **no foreign key**. An invalid value is therefore
accepted silently and only surfaces much later, when the source invoice fails to load — at which
point the trail is cold. `isValidSourceInvoice()` refuses three cases up front:

- an id that matches no invoice;
- an id pointing at another credit note;
- an id pointing at the credit note itself.

Each refusal is logged with the offending id rather than failing quietly.

## Verified

Replayed against a production install carrying 109 credit notes: all 109 resolve to a valid source
under this rule, and the three rejection cases are correctly refused while a genuine invoice is
accepted.

## One question for the maintainers

`CreditNote` currently carries `protected static bool $disabled = true;`, so the object is not
offered at all. This PR deliberately does not touch that flag — enabling the object is a product
decision, not a bug fix. But the field is inert until it is lifted, so I would rather ask than
assume: is the object disabled because it is unfinished, or on purpose?

## Related

Filed as SplashSync/Wordpress#17: WooCommerce refunds are never exported — there is no `CreditNote`
object and no refund hook on that side, so nothing produces the credit note this field would
receive. The two together are what make a refund representable end to end; this one is the half that
can be fixed today.
