### PR TITLE
FIX never unpay an invoice that carries real payments

### DIFF
--- a/splash/src/Objects/Invoice/MainTrait.php
+++ b/splash/src/Objects/Invoice/MainTrait.php
@@ -270,6 +270,18 @@ trait MainTrait
             }
         } else {
             //====================================================================//
+            // Never unpay an invoice that carries real payments: the source's
+            // opinion cannot outrank money already recorded and possibly
+            // reconciled on the bank side.
+            $sqlNbPay = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."paiement_facture WHERE fk_facture = ".((int) $this->object->id);
+            $resNbPay = $this->db->query($sqlNbPay);
+            $objNbPay = $resNbPay ? $this->db->fetch_object($resNbPay) : null;
+            if ($objNbPay && ((int) $objNbPay->nb) > 0) {
+                dol_syslog("splash: invoice ".$this->object->ref." kept paid, carries ".$objNbPay->nb." real payment(s), source opinion ignored", LOG_WARNING);
+
+                return true;
+            }
+            //====================================================================//
             // Set UnPaid using Dolibarr Function
             if ((Facture::STATUS_CLOSED == $this->getInvoiceStatus()) && (1 != $this->object->set_unpaid($user))) {
                 return $this->catchDolibarrErrors();

--- a/splash/src/Objects/Invoice/MainTrait.php
+++ b/splash/src/Objects/Invoice/MainTrait.php
@@ -273,9 +273,14 @@ trait MainTrait
             // Never unpay an invoice that carries real payments: the source's
             // opinion cannot outrank money already recorded and possibly
             // reconciled on the bank side.
-            $sqlNbPay = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."paiement_facture WHERE fk_facture = ".((int) $this->object->id);
-            $resNbPay = $this->db->query($sqlNbPay);
-            $objNbPay = $resNbPay ? $this->db->fetch_object($resNbPay) : null;
+            global $db;
+            if ($this->object instanceof \FactureFournisseur) {
+                $sqlNbPay = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."paiementfourn_facturefourn WHERE fk_facturefourn = ".((int) $this->object->id);
+            } else {
+                $sqlNbPay = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."paiement_facture WHERE fk_facture = ".((int) $this->object->id);
+            }
+            $resNbPay = $db->query($sqlNbPay);
+            $objNbPay = $resNbPay ? $db->fetch_object($resNbPay) : null;
             if ($objNbPay && ((int) $objNbPay->nb) > 0) {
                 dol_syslog("splash: invoice ".$this->object->ref." kept paid, carries ".$objNbPay->nb." real payment(s), source opinion ignored", LOG_WARNING);
 


### PR DESCRIPTION
## Bug

`setPaidFlag(false)` (Invoice `MainTrait`) reopens a closed invoice whenever the source announces *not paid* — even when the invoice carries real, sometimes bank-reconciled, payment entries. The e-commerce side's opinion of the payment state is allowed to outrank recorded money.

Combined with a source that mis-reports its paid flag (see SplashSync/Wordpress#19: `ispaid` derived from the delivery workflow), invoices flip-flop between paid and unpaid on every sync, and accounting states drift.

## Fix

Before unpaying, count the invoice's payment lines: if any exist, keep the invoice paid and log a warning. Mirrors the philosophy of the existing payments-list protections (a source cannot destroy richer local payment knowledge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)