### PR TITLE
FIX never close an invoice the recorded payments do not cover

### DIFF
--- a/splash/src/Objects/Invoice/MainTrait.php
+++ b/splash/src/Objects/Invoice/MainTrait.php
@@ -264,6 +264,41 @@ trait MainTrait
         // Update This Flag
         if ($data) {
             //====================================================================//
+            // Never close an invoice the recorded money does not cover.
+            //
+            // The source knows whether its order was paid. It does not know how
+            // much of THIS invoice has actually been received, because a shop
+            // has a single paid/unpaid state where accounting has a running
+            // balance: a schedule of cheques, a deposit, a settlement part
+            // vouchers part transfer. The shop marks the order paid the day the
+            // arrangement is agreed; the invoice is extinguished only when the
+            // last movement lands.
+            //
+            // An invoice closed early is a receivable that disappears from the
+            // books while it is still owed. Under the French e-invoicing regime
+            // each payment is also reported with its own date, so the missing
+            // movements are never declared either.
+            //
+            // A human may still close a residue by hand in Dolibarr — writing
+            // off a few cents is a decision. A connector may not.
+            $covered = (float) $this->object->getSommePaiement();
+            if (method_exists($this->object, "getSumCreditNotesUsed")) {
+                $covered += (float) $this->object->getSumCreditNotesUsed();
+            }
+            if (method_exists($this->object, "getSumDepositsUsed")) {
+                $covered += (float) $this->object->getSumDepositsUsed();
+            }
+            $invoiceTotal = abs((float) $this->object->total_ttc);
+            if (($invoiceTotal > 1E-6) && ((abs($covered) + 1E-6) < $invoiceTotal)) {
+                dol_syslog(
+                    "splash: invoice ".$this->object->ref." left open, only ".$covered
+                    ." of ".$invoiceTotal." is recorded, source opinion ignored",
+                    LOG_WARNING
+                );
+
+                return true;
+            }
+            //====================================================================//
             // Set Paid using Dolibarr Function
             if ((Facture::STATUS_VALIDATED == $this->getInvoiceStatus()) && (1 != $this->object->set_paid($user))) {
                 return $this->catchDolibarrErrors();


### PR DESCRIPTION
## Bug

`setPaidFlag()` (Invoice `MainTrait`) closes the invoice as soon as the source announces *paid*, without checking that a single cent is recorded against it. The source's opinion is allowed to extinguish a receivable on its own.

A shop has one paid/unpaid state where accounting has a running balance. A schedule of cheques, a deposit, a settlement part vouchers part transfer — all are announced as paid the day the arrangement is agreed, while the invoice is only extinguished when the last movement lands. The connector closes it on day one.

Combined with a source that mis-reports its paid flag (see SplashSync/Wordpress#19), invoices are closed with nothing behind them at all.

Observed in production on one shop: **3 invoices closed by the `splashsync` user with no payment covering them, 704.85 € of receivables that disappeared from the books while still owed** — one of them 612.85 € with zero recorded against it.

An invoice closed early is also an encaissement that will never be declared: under the French e-invoicing regime each payment is reported with its own date.

## Fix

Before closing, count what the invoice already carries — payments, credit notes and deposits — and leave it open when that does not cover the total, logging a warning. Credit notes and deposits count, because an invoice closed by a payment plus a discount is settled just as surely as one closed by payments alone.

A human may still close a residue by hand in Dolibarr; writing off a few cents is a decision. A connector may not.

This is the symmetric half of #30 (*never unpay an invoice that carries real payments*): together they say that the money recorded in Dolibarr decides, in both directions. The two touch different branches of the same `if/else` and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
