### PR TITLE
FIX never add a payment to an invoice that is already settled

### DIFF
--- a/splash/src/Objects/Invoice/PaymentsTrait.php
+++ b/splash/src/Objects/Invoice/PaymentsTrait.php
@@ -461,6 +461,50 @@ trait PaymentsTrait
             || empty((double) $lineData["amount"])) {
             return false;
         }
+        //====================================================================//
+        // Never add a payment to an invoice that is already settled.
+        //
+        // Source lines are paired with local payments by position, and a
+        // payment that is not linked to this invoice is invisible to that
+        // pairing. identifyExistingPayment() is meant to recover those, but it
+        // gives up in exactly the cases that produce them:
+        //
+        //  - getSimilarPayment() requires a non empty "number", which only
+        //    gateway transactions carry. Vouchers, cheques, transfers and cash
+        //    have none, so no lookup is even attempted.
+        //  - it then requires the candidate to already carry invoice totals,
+        //    so a payment linked to no invoice — the very case it should
+        //    catch — is rejected.
+        //
+        // The source line then falls through to createPaymentItem() and the
+        // invoice is settled a second time. Rather than enumerate the causes,
+        // compare against what the invoice already carries: payments, credit
+        // notes and deposits covering the total leave nothing to receive.
+        //
+        // This does not forbid overpaying. A settlement in vouchers or in cash
+        // rarely falls on the exact cent, and such a payment is accepted
+        // because nothing covers the invoice yet when it arrives. What is
+        // refused is the second full settlement of an invoice already closed.
+        $settled = abs((float) $this->object->getSommePaiement());
+        if (method_exists($this->object, "getSumCreditNotesUsed")) {
+            $settled += abs((float) $this->object->getSumCreditNotesUsed());
+        }
+        if (method_exists($this->object, "getSumDepositsUsed")) {
+            $settled += abs((float) $this->object->getSumDepositsUsed());
+        }
+        $invoiceTotal = abs((float) $this->object->total_ttc);
+        if (($invoiceTotal > 1E-6) && (($settled + 1E-6) >= $invoiceTotal)) {
+            Splash::log()->war(sprintf(
+                "Invoice %s already settled (%s of %s): a further payment of %s was refused, "
+                ."it would settle the invoice twice.",
+                $this->object->ref ?? "?",
+                (string) $settled,
+                (string) $invoiceTotal,
+                (string) self::parsePrice($lineData["amount"])
+            ));
+
+            return false;
+        }
         $payment = $this->newPayment();
         //====================================================================//
         // Setup Payment Invoice Id


### PR DESCRIPTION
## Bug

An invoice can be settled twice by a single sync. `setPaymentLineData()` pairs source payment lines with local payments **by position**, taking them from `$this->payments` — which `loadPayments()` fills from the payments *linked to this invoice*. A payment that exists in the database but is linked to no invoice is therefore invisible to the pairing, and its source line has nothing to pair with.

`identifyExistingPayment()` is the safety net for exactly that, and it gives up in exactly the cases that produce it:

- `getSimilarPayment()` bails out on `empty($lineData["number"])`. Only gateway transactions carry a number. Vouchers, cheques, transfers and cash have none, so no lookup is even attempted.
- it then requires `getPaymentInvoicesTotals()` to be non-empty — so a payment carrying no invoice link, the very case it is meant to recover, is rejected.

The line falls through to `createPaymentItem()`, and the invoice ends up with two payments for one movement. The same happens whenever the announced payment method no longer matches the recorded one, since `searchForSimilarPayment()` matches on method + number + date + amount as an exact tuple.

Observed in production on one shop: **12 duplicate payments**, 1 514.76 € of bank entries with no money behind them, in two episodes — 8 left unlinked by a resync in 2025, and 4 attached to their invoice, which then showed twice its amount as settled.

Note that Dolibarr core offers no protection here either: `Paiement::create()` computes `$remaintopay` only to decide whether to close the invoice, and never checks the amount. The interactive form warns (`PaymentHigherThanReminderToPay`) but it is a confirmation dialog, not a refusal — so nothing stops a programmatic overpayment.

## Fix

Rather than enumerate the causes, compare against what the invoice already carries: payments, credit notes and deposits covering the total leave nothing to receive.

This deliberately does **not** forbid overpaying. A settlement in holiday vouchers or in cash rarely falls on the exact cent — 130.00 € of vouchers against a 126.18 € invoice is a real, legitimate payment, and it is accepted because nothing covers the invoice yet when it arrives. What is refused is the second *full* settlement of an invoice already closed.

Mirrors the philosophy of #25 and #30: local, recorded money outranks the source's view of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
