### PR TITLE
FIX write order line product link as an integer

### DIFF
--- a/splash/src/Core/BaseItemsTrait.php
+++ b/splash/src/Core/BaseItemsTrait.php
@@ -621,7 +621,7 @@ trait BaseItemsTrait
         }
         //====================================================================//
         // Update Product Link
-        $this->currentItem->setValueFrom("fk_product", $productId, '', null, '', '', "none");
+        $this->currentItem->setValueFrom("fk_product", $productId, '', null, 'int', '', "none");
         $this->catchDolibarrErrors($this->currentItem);
         //====================================================================//
         // Update Product Type


### PR DESCRIPTION
## Bug

`setValueFrom("fk_product", $productId, "", null, "", "", "none")` passes no type, so Dolibarr quotes the value. When the product link is cleared the UPDATE carries `fk_product = ""`.

Under MySQL `STRICT_TRANS_TABLES` — the default since 5.7 — that is rejected outright. The query fails, nothing is reported to the source, and the line silently keeps the product it had. The sync reports success while the link is unchanged.

## Fix

Pass `int` as the type so Dolibarr emits a numeric value.

Fixes #18. Running in production on a Dolibarr 23.0.0 shop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
