### PR TITLE
FIX set both status properties before deleting an order line

### DIFF
--- a/splash/src/Objects/Order/ItemsTrait.php
+++ b/splash/src/Objects/Order/ItemsTrait.php
@@ -55,6 +55,7 @@ trait ItemsTrait
         //====================================================================//
         // Force Order Status To Draft
         $this->object->statut = 0;
+        $this->object->status = 0;
         //====================================================================//
         // Perform Line Delete
         if ($this->object->deleteline($user, $orderLine->id) <= 0) {


### PR DESCRIPTION
## Bug

`deleteItem()` forces the order back to draft through `$this->object->statut = 0`. That property is deprecated: Dolibarr >= 22 reads `$this->object->status`, which still holds the validated value. `deleteline()` therefore sees a validated order and refuses, so **every** order line deletion fails on recent Dolibarr.

## Fix

Set both properties. One line, and it keeps working on older versions.

Fixes #19. Running in production on a Dolibarr 23.0.0 shop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
