### PR TITLE
FIX name the reference that failed to create, and who already holds it

### DIFF
--- a/splash/src/Objects/Product/CRUDTrait.php
+++ b/splash/src/Objects/Product/CRUDTrait.php
@@ -276,8 +276,33 @@ trait CRUDTrait
         /** @var User $user */
         if ($product->create($user, $triggers ? 0 : 1) <= 0) {
             $this->catchDolibarrErrors($product);
+            //====================================================================//
+            // Name the reference that failed, and who already holds it.
+            //
+            // Dolibarr sanitises the reference on create (a "/" becomes "_"),
+            // so the ref the source sent and the ref stored can differ. Look
+            // for both forms, otherwise "already exists" points at nothing the
+            // operator can find.
+            $conflict = "";
+            $existing = new Product($db);
+            $sanitized = dol_sanitizeFileName(dol_string_nospecial(trim($ref)));
+            $found = ($existing->fetch(0, $ref) > 0)
+                || (($sanitized != $ref) && ($existing->fetch(0, $sanitized) > 0));
+            if ($found) {
+                $conflict = sprintf(
+                    " - reference already used by product id %s (Dolibarr ref: %s / %s)",
+                    $existing->id,
+                    $existing->ref,
+                    $existing->label
+                );
+            }
 
-            return Splash::log()->errNull("Unable to create new Product.");
+            return Splash::log()->errNull(sprintf(
+                "Unable to create new Product [ref: %s / label: %s]%s",
+                $ref,
+                $label,
+                $conflict
+            ));
         }
 
         return $product;


### PR DESCRIPTION
## Bug

`Unable to create new Product.` — that is the whole message. Not the reference, not the label, and above all not which existing product is in the way.

It gets worse: Dolibarr sanitises the reference on create (`dol_sanitizeFileName(dol_string_nospecial(...))`, so `/` becomes `_`). The reference the source sent and the reference stored are then different, the source never finds its product on the next sync, tries to create it again, and fails again. An endless create loop that nothing in the log explains.

## Fix

Report the ref and the label, and look up the conflicting product under **both** the raw and the sanitised form.

Before:
```
Unable to create new Product.
```
After:
```
Unable to create new Product [ref: SAM/BIC/LAC / label: Cours samedi] - reference already used by product id 658 (Dolibarr ref: SAM_BIC_LAC / Cours samedi)
```

Fixes #22. Running in production on a Dolibarr 23.0.0 shop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
