### PR TITLE
FIX refuse to delete a variant parent product

### DIFF
--- a/splash/src/Objects/Product/CRUDTrait.php
+++ b/splash/src/Objects/Product/CRUDTrait.php
@@ -141,6 +141,15 @@ trait CRUDTrait
         // Stack Trace
         Splash::log()->trace();
         //====================================================================//
+        // Deleting a Variant Parent Product is Forbidden!
+        //
+        // Same guard as load(): a parent carries no order line of its own, so
+        // isObjectUsed() believes it is free and Dolibarr deletes it together
+        // with every variant hanging from it.
+        if (VariantsManager::hasProductVariants((int) $objectId)) {
+            return Splash::log()->err(Splash::trans("ProductIsVariantBase"));
+        }
+        //====================================================================//
         // Load Object
         $object = new Product($db);
         //====================================================================//


### PR DESCRIPTION
## Bug

`load()` already refuses to open a variant parent (`ProductIsVariantBase`). `delete()` has no such guard.

A parent carries no order line of its own, so `isObjectUsed()` believes it is free, and `Product::delete()` removes it **together with every variant hanging from it**. One delete instruction from the source, and a whole family is gone — including variants that are used on real orders.

## Fix

Apply the same guard as `load()`, at the top of `delete()` before anything is fetched.

Fixes #23. Running in production on a Dolibarr 23.0.0 shop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
